### PR TITLE
Allow NOT to backtrace

### DIFF
--- a/Data/BoolExpr/Parser.hs
+++ b/Data/BoolExpr/Parser.hs
@@ -35,12 +35,12 @@ parseBoolExpr :: CharParser st a -> CharParser st (BoolExpr a)
 parseBoolExpr parseConst = disj
    where disj   = conj   `chainl1` orOp
          conj   = factor `chainl1` andOp
-         factor =     (  (symbol "-"   >> return BNot)
-                     <|> (symbol "NOT" >> return BNot)
-                     <|> (return id                  )
-                      ) 
-                      `ap` 
-                         (  parens disj 
+         factor =     (      (symbol "-"   >> return BNot)
+                     <|> try (symbol "NOT" >> return BNot)
+                     <|>     (return id                  )
+                      )
+                      `ap`
+                         (  parens disj
                         <|> BConst `fmap` (Positive `fmap` parseConst)
                          )
 

--- a/test/unit/Main.hs
+++ b/test/unit/Main.hs
@@ -30,6 +30,14 @@ parseabilityTests :: TestTree
 parseabilityTests = testGroup "Parseability" [
       testCase "Parsing a nontrivial expression"
         $ tryParse True "(a OR b) AND (n OR m) NOT (x OR y)"
+    , testCase "Parse 'Haskell'"
+        $ tryParse True "Haskell"
+    , testCase "Parse 'Niki' (test that NOT backtraces)"
+        $ tryParse True "Niki"
+    , testCase "Parse 'ORF' (test that OR backtraces)"
+        $ tryParse True "ORF"
+    , testCase "Parse 'ANDY' (test that AND backtraces)"
+        $ tryParse True "ANDY"
     , testCase "Parsing an empty expression"
         $ tryParse False "()"
     ]


### PR DESCRIPTION
Hi @np !

While working on `gargantext` I've stumbled upon a corner case of the library (I don't think it was by design, but feel free to prove me wrong 😉 ): if we try to parse some basic identifiers that starts with `N` (like "Niki") the parser will choke because the `NOT` case does not backtrack, i.e. it starts parsing `N`, consumes it, but then we fail as the input string was not `NOT`.

The fix is simple enough, just adding a `try` before the relevant sub-parser. I don't think that should have any impact of performance, but it allows things like `Niki` to parse correctly as constants. As I was there, I have also added some extra tests to check if the same was happening for things like `AND` or `OR` (which, funnily enough, are fine).

The rest of the chances or merely removing whitespaces from the `Parser.hs` module, but I can remove those, if you don't fancy them.

Thanks a lot for your work!

Alfredo